### PR TITLE
Guard quiz view against invalid parameters

### DIFF
--- a/words/tests.py
+++ b/words/tests.py
@@ -1,3 +1,21 @@
 from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
 
-# Create your tests here.
+
+class QuizViewTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="tester", password="pass")
+
+    def test_quiz_without_num_quiz(self):
+        self.client.login(username="tester", password="pass")
+        response = self.client.get(reverse("words:quiz"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "base.html")
+
+    def test_quiz_with_invalid_num_quiz(self):
+        self.client.login(username="tester", password="pass")
+        response = self.client.get(reverse("words:quiz"), {"num_quiz": "abc"})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "base.html")

--- a/words/views.py
+++ b/words/views.py
@@ -14,7 +14,10 @@ def index(request):
 
 @require_http_methods(['GET'])
 def quiz(request):
-    num_quiz = int(request.GET.get("num_quiz"))
+    try:
+        num_quiz = int(request.GET.get("num_quiz", "0"))
+    except (TypeError, ValueError):
+        num_quiz = 0
     if num_quiz <= 0:
         return render(request, "base.html")
     words = Word.objects.all().order_by('order')[:num_quiz]


### PR DESCRIPTION
## Summary
- handle missing or invalid `num_quiz` values in `quiz` view
- test quiz view behavior with invalid or absent `num_quiz` query parameter

## Testing
- `python manage.py test -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6842f68657a48321bf17d6887a622214